### PR TITLE
fix: guard selected actions by card index

### DIFF
--- a/src/app/[selectedClass]/play/@selectedCards/page.tsx
+++ b/src/app/[selectedClass]/play/@selectedCards/page.tsx
@@ -53,14 +53,23 @@ export default function PlayedCards<X extends Card>() {
     const cardIndex = selectedCards.indexOf(card);
     const [firstAction, secondAction] = [...selectedActions];
 
-    setSelectedActions(cardIndex
-      ? [action !== 'default' && action === firstAction
-        ? undefined : firstAction,
-        action]
-      : [action,
+    if (cardIndex === 1) {
+      setSelectedActions([
+        action !== 'default' && action === firstAction
+          ? undefined
+          : firstAction,
+        action,
+      ]);
+    } else if (cardIndex === 0) {
+      setSelectedActions([
+        action,
         action !== 'default' && action === secondAction
-          ? undefined : secondAction]
-    );
+          ? undefined
+          : secondAction,
+      ]);
+    } else {
+      return;
+    }
   };
 
   const playTopAction = (card: X) => ({


### PR DESCRIPTION
## Summary
- avoid corrupting selected actions when card index is unexpected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab754a26c48333ba6fbd1063641866