### PR TITLE
Map additional Frosthaven classes to secretary slugs

### DIFF
--- a/src/domain/secretary/secretary-character.mapper.ts
+++ b/src/domain/secretary/secretary-character.mapper.ts
@@ -1,8 +1,8 @@
 import type { Card } from '../cards.type';
-import { type FrosthavenClass } from '../frosthaven-class.type';
+import { type FrosthavenClass, type FrosthavenClassNames } from '../frosthaven-class.type';
 
 export function mapCharacterNameToSecretary(name: FrosthavenClass<Card>['name']) {
-  return {
+  const map: Record<FrosthavenClassNames, string> = {
     'Banner Spear': 'banner-spear',
     'Bladeswarm': 'envx',
     'Blinkblade': 'blinkblade',
@@ -21,5 +21,11 @@ export function mapCharacterNameToSecretary(name: FrosthavenClass<Card>['name'])
     'Shattersong': 'shards',
     'Snowdancer': 'snowflake',
     'Trapper': 'trap',
-  }[name];
+    'Red Guard': 'red-guard',
+    'Hatchet': 'hatchet',
+    'Demolitionist': 'demolitionist',
+    'Voidwarden': 'voidwarden',
+  };
+
+  return map[name];
 }


### PR DESCRIPTION
## Summary
- include Red Guard, Hatchet, Demolitionist, and Voidwarden in the secretary character map
- type the character map as `Record<FrosthavenClassNames, string>` to ensure all names are handled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab78d4a3808333b14cac4b8f3357e7