### PR TITLE
feat: add counter for active cards

### DIFF
--- a/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
+++ b/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
@@ -28,6 +28,8 @@ export default function ActiveEffects<X extends Card>() {
     currentCards,
     discardCard,
     loseCard,
+    incrementCounter,
+    decrementCounter,
   } = useCards<X>();
   const {
     activateHiveMode,
@@ -83,7 +85,34 @@ export default function ActiveEffects<X extends Card>() {
     </Modal>}
     <AnimatePresence mode='popLayout'>
       {activeEffects
-        .map((card) => getCardComponent(card))}
+        .map((card) => (
+          <div key={card.name} className='relative group'>
+            {getCardComponent(card)}
+            {typeof card.counter === 'number' && (
+              <div className='absolute top-1 left-1 flex items-center bg-primary text-white rounded px-1 text-xs z-40'>
+                <span>{card.counter}</span>
+                <div className='flex opacity-0 group-hover:opacity-100 ml-1 pointer-events-none group-hover:pointer-events-auto'>
+                  <button
+                    aria-label='decrease counter'
+                    className='px-1'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      decrementCounter(card);
+                    }}
+                  >-</button>
+                  <button
+                    aria-label='increase counter'
+                    className='px-1'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      incrementCounter(card);
+                    }}
+                  >+</button>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
     </AnimatePresence>
   </div>
 }

--- a/src/app/[selectedClass]/play/useCards.ts
+++ b/src/app/[selectedClass]/play/useCards.ts
@@ -42,7 +42,8 @@ export function useCards<X extends Card>() {
   const changeCardStatus = (newStatus: CardStatus, condition?: () => boolean) => (card: X) => {
     if (condition && !condition()) return;
     const otherCards = currentCards.filter(c => c !== card);
-    const newState = [...otherCards, { ...card, status: newStatus }];
+    const newCard: X = { ...card, status: newStatus, counter: undefined };
+    const newState = [...otherCards, newCard];
     updateStates([...states.slice(0, currentStateIndex + 1), newState]);
   };
 
@@ -69,9 +70,35 @@ export function useCards<X extends Card>() {
   const playCards = (cardsPlayed: { action: Action; card: X }[]) => {
     const newState = [
       ...currentCards.filter(card => !cardsPlayed.map(({ card }) => card.name).includes(card.name)),
-      ...cardsPlayed.map(({ action, card }) => ({ ...card, status: newStatusAfterAction(card.actions, action) })),
+      ...cardsPlayed.map(({ action, card }) => {
+        const status = newStatusAfterAction(card.actions, action);
+        return {
+          ...card,
+          status,
+          ...(status === 'activeTop' || status === 'activeBottom'
+            ? { counter: 1 }
+            : { counter: undefined }),
+        } as X;
+      }),
     ];
 
+    updateStates([...states.slice(0, currentStateIndex + 1), newState]);
+  };
+
+  const incrementCounter = (card: X) => {
+    const index = currentCards.findIndex(c => c === card);
+    if (index === -1) return;
+    const newCard = { ...card, counter: (card.counter ?? 1) + 1 } as X;
+    const newState = currentCards.with(index, newCard);
+    updateStates([...states.slice(0, currentStateIndex + 1), newState]);
+  };
+
+  const decrementCounter = (card: X) => {
+    const index = currentCards.findIndex(c => c === card);
+    if (index === -1) return;
+    const newValue = (card.counter ?? 1) - 1;
+    const newCard = { ...card, counter: newValue > 0 ? newValue : 0 } as X;
+    const newState = currentCards.with(index, newCard);
     updateStates([...states.slice(0, currentStateIndex + 1), newState]);
   };
 
@@ -109,5 +136,7 @@ export function useCards<X extends Card>() {
     undo,
     redo,
     setSelectedActions,
+    incrementCounter,
+    decrementCounter,
   };
 }

--- a/src/domain/cards.type.ts
+++ b/src/domain/cards.type.ts
@@ -32,6 +32,7 @@ export interface Card {
   initiative: number;
   slots?: SlotArea[];
   tokenPosition?: number;
+  counter?: number;
   availableEnhancements?: EnhancementSlot[];
   enhancements?: (Enhancement | undefined)[];
 }

--- a/src/stores/cards.store.ts
+++ b/src/stores/cards.store.ts
@@ -35,7 +35,8 @@ export type PersistedCard =
     | 'name'
     | 'status'
     | 'tokenPosition'
-    | 'enhancements'>
+    | 'enhancements'
+    | 'counter'>
   & Pick<HiveCard, 'isSelectedMode'>;
 export interface PersistedState {
   level: number;
@@ -49,7 +50,8 @@ export function partializeCard<X extends HiveCard>({
   status,
   tokenPosition,
   enhancements,
-  isSelectedMode
+  isSelectedMode,
+  counter
 }: X): PersistedCard {
   return {
     name,
@@ -57,6 +59,7 @@ export function partializeCard<X extends HiveCard>({
     tokenPosition,
     enhancements,
     isSelectedMode,
+    counter,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `counter` field to cards and persist it
- track counters in play state and expose increment/decrement helpers
- display counter with hoverable +/- controls on active cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f1bbb748333920822f1eb25bf13