### PR TITLE
Enable horizontal scrolling for card piles on mobile

### DIFF
--- a/src/app/_components/cards/CardPile.tsx
+++ b/src/app/_components/cards/CardPile.tsx
@@ -83,38 +83,40 @@ export default function CardPile<X extends Card>({
 
   const minWidthValue = maxCardLength > 1 ? minWidthValues[maxCardLength - 1] : '';
 
-  return <div
-    ref={pileRef}
-    className={`flex min-h-card ${minWidthValue}`}
-    onMouseLeave={() => setFocusCardIndex(null)}
-    onTouchMove={handleTouchMove}
-  >
-    <LazyMotion features={domAnimation}>
-      <AnimatePresence mode='popLayout'>
-        {cards
-          .map((card, index) => <m.div
-            key={card.name}
-            onMouseEnter={() => setFocusCardIndex(index)}
-            onTouchStart={() => setFocusCardIndex(index)}
-            onFocus={() => setFocusCardIndex(index)}
-            className={maxCardLength < 11
-              ? '-mr-card-1/2'
-              : marginRightForLongHand[maxCardLength as LongHandSize]
-            }
-            animate={{
-              scale: focusCardIndex === index ? 1.2 : 1,
-              zIndex: getZIndex(index),
-            }}
-          >
-            <CardComponent
-              card={card}
-              onCloseCard={onCloseCard && index === focusCardIndex
-                ? () => onCloseCard(card)
-                : undefined
+  return <div className='w-full overflow-x-auto'>
+    <div
+      ref={pileRef}
+      className={`flex min-h-card ${minWidthValue}`}
+      onMouseLeave={() => setFocusCardIndex(null)}
+      onTouchMove={handleTouchMove}
+    >
+      <LazyMotion features={domAnimation}>
+        <AnimatePresence mode='popLayout'>
+          {cards
+            .map((card, index) => <m.div
+              key={card.name}
+              onMouseEnter={() => setFocusCardIndex(index)}
+              onTouchStart={() => setFocusCardIndex(index)}
+              onFocus={() => setFocusCardIndex(index)}
+              className={maxCardLength < 11
+                ? '-mr-card-1/2'
+                : marginRightForLongHand[maxCardLength as LongHandSize]
               }
-              actions={actions(card)} />
-          </m.div>)}
-      </AnimatePresence>
-    </LazyMotion>
+              animate={{
+                scale: focusCardIndex === index ? 1.2 : 1,
+                zIndex: getZIndex(index),
+              }}
+            >
+              <CardComponent
+                card={card}
+                onCloseCard={onCloseCard && index === focusCardIndex
+                  ? () => onCloseCard(card)
+                  : undefined
+                }
+                actions={actions(card)} />
+            </m.div>)}
+        </AnimatePresence>
+      </LazyMotion>
+    </div>
   </div>;
 }


### PR DESCRIPTION
## Summary
- wrap card piles in horizontally scrollable container to keep all cards visible on narrow screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac2cd345908333adb090a2ddafc00c