### PR TITLE
Enable horizontal scrolling for class card groups on mobile

### DIFF
--- a/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
+++ b/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
@@ -72,47 +72,49 @@ export default function ActiveEffects<X extends Card>() {
 
   const cardsWithMode = currentCards.filter(cardHasMode);
 
-  return <div className='grid grid-cols-3 gap-4 min-w-[461px] min-h-card'>
-    {isSelectingMode && <Modal onCancel={() => setIsSelectingMode(false)}>
-      <BoardArea title="Select mode">
-        <CardPile
-          cards={cardsWithMode}
-          actions={activateHiveModeAction}
-          maxCardLength={cardsWithMode.length}
-          onCloseCard={removeEffectAction}
-        />
-      </BoardArea>
-    </Modal>}
-    <AnimatePresence mode='popLayout'>
-      {activeEffects
-        .map((card) => (
-          <div key={card.name} className='relative group'>
-            {getCardComponent(card)}
-            {typeof card.counter === 'number' && (
-              <div className='absolute top-1 left-1 flex items-center bg-primary text-white rounded px-1 text-xs z-40'>
-                <span>{card.counter}</span>
-                <div className='flex opacity-0 group-hover:opacity-100 ml-1 pointer-events-none group-hover:pointer-events-auto'>
-                  <button
-                    aria-label='decrease counter'
-                    className='px-1'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      decrementCounter(card);
-                    }}
-                  >-</button>
-                  <button
-                    aria-label='increase counter'
-                    className='px-1'
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      incrementCounter(card);
-                    }}
-                  >+</button>
+  return <div className='w-full overflow-x-auto'>
+    <div className='grid grid-cols-3 gap-4 min-w-[461px] min-h-card'>
+      {isSelectingMode && <Modal onCancel={() => setIsSelectingMode(false)}>
+        <BoardArea title="Select mode">
+          <CardPile
+            cards={cardsWithMode}
+            actions={activateHiveModeAction}
+            maxCardLength={cardsWithMode.length}
+            onCloseCard={removeEffectAction}
+          />
+        </BoardArea>
+      </Modal>}
+      <AnimatePresence mode='popLayout'>
+        {activeEffects
+          .map((card) => (
+            <div key={card.name} className='relative group'>
+              {getCardComponent(card)}
+              {typeof card.counter === 'number' && (
+                <div className='absolute top-1 left-1 flex items-center bg-primary text-white rounded px-1 text-xs z-40'>
+                  <span>{card.counter}</span>
+                  <div className='flex opacity-0 group-hover:opacity-100 ml-1 pointer-events-none group-hover:pointer-events-auto'>
+                    <button
+                      aria-label='decrease counter'
+                      className='px-1'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        decrementCounter(card);
+                      }}
+                    >-</button>
+                    <button
+                      aria-label='increase counter'
+                      className='px-1'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        incrementCounter(card);
+                      }}
+                    >+</button>
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        ))}
-    </AnimatePresence>
+              )}
+            </div>
+          ))}
+      </AnimatePresence>
+    </div>
   </div>
 }

--- a/src/app/[selectedClass]/play/@selectedCards/page.tsx
+++ b/src/app/[selectedClass]/play/@selectedCards/page.tsx
@@ -117,19 +117,21 @@ export default function PlayedCards<X extends Card>() {
     : undefined;
 
   return <BoardArea title='Selected cards' actions={actions}>
-    <div className='flex gap-4 min-h-card min-w-[302px]'>
-      <AnimatePresence mode='popLayout'>
-        {selectedCards
-          .map((card, index) => <CardComponent
-            autoFocus={index === 1}
-            key={card.name}
-            card={card}
-            actions={getPlayableActions(card)}
-            onCloseCard={() => recoverCard(selectedCards[index])}
-          >
-            {selectedActions[index] && getSelectedActionMasks(selectedActions[index])}
-          </CardComponent>)}
-      </AnimatePresence>
+    <div className='w-full overflow-x-auto'>
+      <div className='flex gap-4 min-h-card min-w-[302px]'>
+        <AnimatePresence mode='popLayout'>
+          {selectedCards
+            .map((card, index) => <CardComponent
+              autoFocus={index === 1}
+              key={card.name}
+              card={card}
+              actions={getPlayableActions(card)}
+              onCloseCard={() => recoverCard(selectedCards[index])}
+            >
+              {selectedActions[index] && getSelectedActionMasks(selectedActions[index])}
+            </CardComponent>)}
+        </AnimatePresence>
+      </div>
     </div>
   </BoardArea>;
 }

--- a/src/app/_components/cards/CardPile.tsx
+++ b/src/app/_components/cards/CardPile.tsx
@@ -83,38 +83,40 @@ export default function CardPile<X extends Card>({
 
   const minWidthValue = maxCardLength > 1 ? minWidthValues[maxCardLength - 1] : '';
 
-  return <div
-    ref={pileRef}
-    className={`flex min-h-card ${minWidthValue}`}
-    onMouseLeave={() => setFocusCardIndex(null)}
-    onTouchMove={handleTouchMove}
-  >
-    <LazyMotion features={domAnimation}>
-      <AnimatePresence mode='popLayout'>
-        {cards
-          .map((card, index) => <m.div
-            key={card.name}
-            onMouseEnter={() => setFocusCardIndex(index)}
-            onTouchStart={() => setFocusCardIndex(index)}
-            onFocus={() => setFocusCardIndex(index)}
-            className={maxCardLength < 11
-              ? '-mr-card-1/2'
-              : marginRightForLongHand[maxCardLength as LongHandSize]
-            }
-            animate={{
-              scale: focusCardIndex === index ? 1.2 : 1,
-              zIndex: getZIndex(index),
-            }}
-          >
-            <CardComponent
-              card={card}
-              onCloseCard={onCloseCard && index === focusCardIndex
-                ? () => onCloseCard(card)
-                : undefined
+  return <div className='w-full overflow-x-auto'>
+    <div
+      ref={pileRef}
+      className={`flex min-h-card ${minWidthValue}`}
+      onMouseLeave={() => setFocusCardIndex(null)}
+      onTouchMove={handleTouchMove}
+    >
+      <LazyMotion features={domAnimation}>
+        <AnimatePresence mode='popLayout'>
+          {cards
+            .map((card, index) => <m.div
+              key={card.name}
+              onMouseEnter={() => setFocusCardIndex(index)}
+              onTouchStart={() => setFocusCardIndex(index)}
+              onFocus={() => setFocusCardIndex(index)}
+              className={maxCardLength < 11
+                ? '-mr-card-1/2'
+                : marginRightForLongHand[maxCardLength as LongHandSize]
               }
-              actions={actions(card)} />
-          </m.div>)}
-      </AnimatePresence>
-    </LazyMotion>
+              animate={{
+                scale: focusCardIndex === index ? 1.2 : 1,
+                zIndex: getZIndex(index),
+              }}
+            >
+              <CardComponent
+                card={card}
+                onCloseCard={onCloseCard && index === focusCardIndex
+                  ? () => onCloseCard(card)
+                  : undefined
+                }
+                actions={actions(card)} />
+            </m.div>)}
+        </AnimatePresence>
+      </LazyMotion>
+    </div>
   </div>;
 }


### PR DESCRIPTION
## Summary
- wrap active effects grid in full-width horizontally scrollable container
- allow selected card area to scroll so overflowing cards remain accessible on narrow screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac2cd345908333adb090a2ddafc00c