### PR TITLE
Stack card groups for mobile-friendly layout

### DIFF
--- a/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
+++ b/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
@@ -72,7 +72,7 @@ export default function ActiveEffects<X extends Card>() {
 
   const cardsWithMode = currentCards.filter(cardHasMode);
 
-  return <div className='grid grid-cols-3 gap-4 min-w-[461px] min-h-card'>
+  return <div className='grid grid-cols-2 md:grid-cols-3 gap-4 min-h-card'>
     {isSelectingMode && <Modal onCancel={() => setIsSelectingMode(false)}>
       <BoardArea title="Select mode">
         <CardPile

--- a/src/app/[selectedClass]/play/@selectedCards/page.tsx
+++ b/src/app/[selectedClass]/play/@selectedCards/page.tsx
@@ -117,7 +117,7 @@ export default function PlayedCards<X extends Card>() {
     : undefined;
 
   return <BoardArea title='Selected cards' actions={actions}>
-    <div className='flex gap-4 min-h-card min-w-[302px]'>
+    <div className='flex flex-col items-center gap-4 min-h-card sm:flex-row sm:min-w-[302px]'>
       <AnimatePresence mode='popLayout'>
         {selectedCards
           .map((card, index) => <CardComponent

--- a/src/app/_components/cards/CardPile.tsx
+++ b/src/app/_components/cards/CardPile.tsx
@@ -81,11 +81,11 @@ export default function CardPile<X extends Card>({
     }
   };
 
-  const minWidthValue = maxCardLength > 1 ? minWidthValues[maxCardLength - 1] : '';
+  const minWidthValue = maxCardLength > 1 ? `md:${minWidthValues[maxCardLength - 1]}` : '';
 
   return <div
     ref={pileRef}
-    className={`flex min-h-card ${minWidthValue}`}
+    className={`min-h-card grid grid-cols-2 gap-2 justify-center md:flex md:gap-0 ${minWidthValue}`}
     onMouseLeave={() => setFocusCardIndex(null)}
     onTouchMove={handleTouchMove}
   >
@@ -98,8 +98,8 @@ export default function CardPile<X extends Card>({
             onTouchStart={() => setFocusCardIndex(index)}
             onFocus={() => setFocusCardIndex(index)}
             className={maxCardLength < 11
-              ? '-mr-card-1/2'
-              : marginRightForLongHand[maxCardLength as LongHandSize]
+              ? 'md:-mr-card-1/2'
+              : `md:${marginRightForLongHand[maxCardLength as LongHandSize]}`
             }
             animate={{
               scale: focusCardIndex === index ? 1.2 : 1,


### PR DESCRIPTION
## Summary
- show card piles as a two-column grid on small screens
- display active effects and selected cards in responsive layouts to avoid overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac2cd345908333adb090a2ddafc00c