### PR TITLE
fix: show active card counter controls on mobile

### DIFF
--- a/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
+++ b/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
@@ -91,7 +91,7 @@ export default function ActiveEffects<X extends Card>() {
             {typeof card.counter === 'number' && (
               <div className='absolute top-1 left-1 flex items-center bg-primary text-white rounded px-1 text-xs z-40'>
                 <span>{card.counter}</span>
-                <div className='flex opacity-0 group-hover:opacity-100 ml-1 pointer-events-none group-hover:pointer-events-auto'>
+                <div className='flex ml-1 md:opacity-0 md:group-hover:opacity-100 md:pointer-events-none md:group-hover:pointer-events-auto'>
                   <button
                     aria-label='decrease counter'
                     className='px-1'


### PR DESCRIPTION
## Summary
- ensure active card counter controls remain visible on mobile devices
- preserve hover-based visibility for controls on larger screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68accc90cb7083339ff371738bc165fa