### PR TITLE
fix: show active card counter controls on mobile

### DIFF
--- a/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
+++ b/src/app/[selectedClass]/play/@activeEffects/ActiveEffects.tsx
@@ -91,7 +91,7 @@ export default function ActiveEffects<X extends Card>() {
             {typeof card.counter === 'number' && (
               <div className='absolute top-1 left-1 flex items-center bg-primary text-white rounded px-1 text-xs z-40'>
                 <span>{card.counter}</span>
-                <div className='flex opacity-0 group-hover:opacity-100 ml-1 pointer-events-none group-hover:pointer-events-auto'>
+                <div className='flex ml-1 md:opacity-0 md:group-hover:opacity-100 md:pointer-events-none md:group-hover:pointer-events-auto'>
                   <button
                     aria-label='decrease counter'
                     className='px-1'

--- a/src/app/[selectedClass]/play/@lostCards/LostCards.tsx
+++ b/src/app/[selectedClass]/play/@lostCards/LostCards.tsx
@@ -25,5 +25,6 @@ export default function LostCards() {
     cards={lostPile}
     actions={recoverAction}
     maxCardLength={fhClass.handSize}
+    showActionWheelForSingleAction
   />;
 }

--- a/src/app/[selectedClass]/play/@selectedCards/page.tsx
+++ b/src/app/[selectedClass]/play/@selectedCards/page.tsx
@@ -11,10 +11,10 @@ import BoardArea from '@/app/_components/layout/BoardArea';
 
 const bottomActionMask = <div
   key={'mask-action-top'}
-  className='m-2 absolute bg-black/80 left-0 w-action h-action top-[108px]' />;
+  className='absolute left-2 right-2 bottom-2 top-1/2 bg-black/80 pointer-events-none' />;
 const topActionMask = <div
   key={'mask-action-bottom'}
-  className='m-2 absolute bg-black/80 left-0 w-action h-action top-[12px]' />;
+  className='absolute left-2 right-2 top-2 bottom-1/2 bg-black/80 pointer-events-none' />;
 
 function getSelectedActionMasks(action: Action) {
   const masks = [];

--- a/src/app/_components/cards/Card.tsx
+++ b/src/app/_components/cards/Card.tsx
@@ -15,6 +15,7 @@ export function CardComponent<X extends Card>({
   mapName,
   autoFocus,
   onCloseCard,
+  showActionWheelForSingleAction = false,
 }: {
   card: X;
   children?: ReactNode;
@@ -22,13 +23,14 @@ export function CardComponent<X extends Card>({
   mapName?: string;
   autoFocus?: boolean;
   onCloseCard?: () => void;
+  showActionWheelForSingleAction?: boolean;
 }): ReactNode {
   const innerRef = useRef<HTMLDivElement>(null);
   const [isActionWheelOpen, setIsActionWheelOpen] = useState(false);
 
   const onClickCard = () => {
     if (actions.length === 0) return;
-    if (actions.length === 1) {
+    if (actions.length === 1 && !showActionWheelForSingleAction) {
       actions[0].onClick();
       return;
     }

--- a/src/app/_components/cards/CardPile.tsx
+++ b/src/app/_components/cards/CardPile.tsx
@@ -37,11 +37,13 @@ export default function CardPile<X extends Card>({
   actions,
   maxCardLength = 1,
   onCloseCard,
+  showActionWheelForSingleAction,
 }: {
   cards: X[];
   actions: PileActions<X>;
   maxCardLength?: number;
   onCloseCard?: (card: X) => void;
+  showActionWheelForSingleAction?: boolean;
 }) {
   const [focusCardIndex, setFocusCardIndex] = useState<number | null>(null);
   const pileRef = useRef<HTMLDivElement>(null);
@@ -112,7 +114,8 @@ export default function CardPile<X extends Card>({
                 ? () => onCloseCard(card)
                 : undefined
               }
-              actions={actions(card)} />
+              actions={actions(card)}
+              showActionWheelForSingleAction={showActionWheelForSingleAction} />
           </m.div>)}
       </AnimatePresence>
     </LazyMotion>


### PR DESCRIPTION
## Summary
- ensure active card counter controls remain visible on mobile devices
- preserve hover-based visibility for controls on larger screens
- require confirmation before recovering a lost card
- fix action mask positioning on mobile so selected actions black out the correct card half

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68accc90cb7083339ff371738bc165fa