### PR TITLE
fix: scale card piles on wide screens

### DIFF
--- a/src/app/[selectedClass]/select/@cardsForLevelUp/AvailableCardsByLevel.tsx
+++ b/src/app/[selectedClass]/select/@cardsForLevelUp/AvailableCardsByLevel.tsx
@@ -6,7 +6,7 @@ import type { Card } from '@/domain/cards.type';
 import { useSelectCards } from '@/app/[selectedClass]/select/useSelectCards';
 import { useFrosthavenStore } from '@/stores/cards.store';
 import { ClassContext } from '@/context/ClassContext';
-import { use } from 'react';
+import { use, useCallback, useMemo } from 'react';
 
 export default function AvailableCardsByLevel<X extends Card>({
   level,
@@ -17,21 +17,31 @@ export default function AvailableCardsByLevel<X extends Card>({
   const currentClass = use(ClassContext);
   const { cards, selectCard } = useSelectCards<X>();
 
-  const selectAction = (card: X) => [{
+  const selectAction = useCallback((card: X) => [{
     name: 'Select Card',
     onClick: () => selectCard(card),
-  }];
+  }], [selectCard]);
 
-  const filterRemainingCards = (card: X) => cards.every(({ path }) => path !== card.path);
-  const levelCards = availableCards.filter((card: X) => level === card.level);
+  const levelCards = useMemo(
+    () => availableCards.filter((card: X) => level === card.level),
+    [availableCards, level],
+  );
+
+  const remainingCards = useMemo(
+    () => levelCards.filter((card) => cards.every(({ path }) => path !== card.path)),
+    [levelCards, cards],
+  );
+
+  const maxCardLength = useMemo(
+    () => currentClass.cards.filter((card: Card) => level === card.level).length,
+    [currentClass.cards, level],
+  );
 
   return <BoardArea title={`Cards level ${level}`}>
     <CardPile
-      cards={levelCards.filter(filterRemainingCards)}
+      cards={remainingCards}
       actions={selectAction}
-      maxCardLength={currentClass.cards
-        .filter((card: Card) => level === card.level)
-        .length}
+      maxCardLength={maxCardLength}
     />
   </BoardArea>;
-};
+}

--- a/src/app/_components/cards/CardPile.tsx
+++ b/src/app/_components/cards/CardPile.tsx
@@ -1,25 +1,25 @@
 import { Card } from '@/domain/cards.type';
 import { AnimatePresence, domAnimation, LazyMotion } from 'motion/react';
 import * as m from 'motion/react-m';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { WheelAction } from './ActionWheel';
 import { CardComponent } from './Card';
 
 const minWidthValues = [
-  'min-w-cards-1',
-  'min-w-cards-2',
-  'min-w-cards-3',
-  'min-w-cards-4',
-  'min-w-cards-5',
-  'min-w-cards-6',
-  'min-w-cards-7',
-  'min-w-cards-8',
-  'min-w-cards-9',
-  'min-w-cards-10',
-  'min-w-cards-11',
-  'min-w-cards-12',
-  'min-w-cards-13',
-  'min-w-cards-14',
+  'min-w-[var(--min-width-cards-1)]',
+  'min-w-[var(--min-width-cards-2)]',
+  'min-w-[var(--min-width-cards-3)]',
+  'min-w-[var(--min-width-cards-4)]',
+  'min-w-[var(--min-width-cards-5)]',
+  'min-w-[var(--min-width-cards-6)]',
+  'min-w-[var(--min-width-cards-7)]',
+  'min-w-[var(--min-width-cards-8)]',
+  'min-w-[var(--min-width-cards-9)]',
+  'min-w-[var(--min-width-cards-10)]',
+  'min-w-[var(--min-width-cards-11)]',
+  'min-w-[var(--min-width-cards-12)]',
+  'min-w-[var(--min-width-cards-13)]',
+  'min-w-[var(--min-width-cards-14)]',
 ];
 
 type LongHandSize = 11 | 12 | 13 | 14;
@@ -56,7 +56,7 @@ export default function CardPile<X extends Card>({
 
   useEffect(() => setFocusCardIndex(null), [cards.length]);
 
-  const handleTouchMove = ({ touches }: React.TouchEvent) => {
+  const handleTouchMove = useCallback(({ touches }: React.TouchEvent) => {
     if (pileRef.current) {
       const touch = touches[0];
       const pile = pileRef.current;
@@ -81,9 +81,14 @@ export default function CardPile<X extends Card>({
         setFocusCardIndex(touchedCard);
       }
     }
-  };
+  }, [cards]);
 
-  const minWidthValue = maxCardLength > 1 ? `md:${minWidthValues[maxCardLength - 1]}` : '';
+  const minWidthValue = useMemo(
+    () => maxCardLength > 1
+      ? `md:${minWidthValues[Math.min(maxCardLength - 1, minWidthValues.length - 1)]}`
+      : '',
+    [maxCardLength],
+  );
 
   return <div
     ref={pileRef}


### PR DESCRIPTION
## Summary
- scale card piles using CSS variable based min widths
- memoize card filtering and actions per level for better performance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0ceedf24c8333a7bda451d1dee937