### PR TITLE
Fix card selection box width on large screens

### DIFF
--- a/src/app/[selectedClass]/select/layout.tsx
+++ b/src/app/[selectedClass]/select/layout.tsx
@@ -13,7 +13,7 @@ export default function SelectCardsLayout({
       {children}
     </BoardArea>
 
-    <div className='flex flex-col gap-4 items-center w-full max-w-[811px]'>
+    <div className='flex flex-col gap-4 items-center w-full md:w-fit'>
       {selectedCards}
 
       <AvailableCardsByLevel level={1} />


### PR DESCRIPTION
## Summary
- allow card selection column to size to its content on desktop to prevent cards overflowing their boxes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be62990c4c8333b2a3b57423782654